### PR TITLE
Allow one-dimensional image resize

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -3,7 +3,7 @@ server {
     # error_log /var/log/nginx/error.log debug;
 
     # Uses the Nginx image filter module to dynamically resize and store the resized image on server
-    # http://wiki.nginx.org/HttpImageFilterModule
+    # http://nginx.org/en/docs/http/ngx_http_image_filter_module.html
 
     # Modified from an original gist:
     # https://gist.github.com/phpdude/1451684
@@ -52,9 +52,9 @@ server {
         log_not_found off;
     }
 
-    # http://wiki.nginx.org/HttpImageFilterModule#image_filter
+    # http://nginx.org/en/docs/http/ngx_http_image_filter_module.html#image_filter
     # commands test, rotate, size, crop, resize
-    location ~ ^/(resize|crop)/(\d+)x(\d+)/(.*) {
+    location ~ ^/(resize|crop)/(-|\d+)x(-|\d+)/(.*) {
         set $command $1;
         set $arg1 $2;
         set $arg2 $3;


### PR DESCRIPTION
According to http://nginx.org/en/docs/http/ngx_http_image_filter_module.html#image_filter the `resize` method allows for either width or height to be `-` to resize the image in only one dimension
